### PR TITLE
WIP: Df/220 update accounts

### DIFF
--- a/ilpv4-connector-accounts/src/main/java/org/interledger/connector/accounts/AccountProblem.java
+++ b/ilpv4-connector-accounts/src/main/java/org/interledger/connector/accounts/AccountProblem.java
@@ -23,6 +23,11 @@ public abstract class AccountProblem extends AbstractConnectorProblem {
     this.accountId = Objects.requireNonNull(accountId, "accountId must not be null!");
   }
 
+  public AccountProblem(URI type, String title, StatusType status, AccountId accountId, String details) {
+    super(type, title, status, details);
+    this.accountId = Objects.requireNonNull(accountId, "accountId must not be null!");
+  }
+
   /**
    * The {@link AccountId} of the account that threw this exception.
    */

--- a/ilpv4-connector-accounts/src/main/java/org/interledger/connector/accounts/InvalidAccountDetailsProblem.java
+++ b/ilpv4-connector-accounts/src/main/java/org/interledger/connector/accounts/InvalidAccountDetailsProblem.java
@@ -1,0 +1,22 @@
+package org.interledger.connector.accounts;
+
+import org.zalando.problem.Status;
+
+import java.net.URI;
+import java.util.Objects;
+
+/**
+ * Thrown if supplied account details are not configured properly.
+ */
+public class InvalidAccountDetailsProblem extends AccountProblem {
+
+  public InvalidAccountDetailsProblem(final AccountId accountId, final String details) {
+    super(
+      URI.create(TYPE_PREFIX + ACCOUNTS_PATH + "/invalid-account-details"),
+      "Invalid Account Details",
+      Status.BAD_REQUEST,
+      Objects.requireNonNull(accountId),
+      details
+    );
+  }
+}

--- a/ilpv4-connector-server/src/main/java/com/sappenin/interledger/ilpv4/connector/server/spring/controllers/admin/AccountsController.java
+++ b/ilpv4-connector-server/src/main/java/com/sappenin/interledger/ilpv4/connector/server/spring/controllers/admin/AccountsController.java
@@ -4,8 +4,6 @@ import com.sappenin.interledger.ilpv4.connector.accounts.AccountManager;
 import com.sappenin.interledger.ilpv4.connector.server.spring.controllers.model.problems.AccountNotFoundProblem;
 import org.interledger.connector.accounts.AccountId;
 import org.interledger.connector.accounts.AccountSettings;
-import org.interledger.ilpv4.connector.persistence.entities.AccountBalanceSettingsEntity;
-import org.interledger.ilpv4.connector.persistence.entities.AccountRateLimitSettingsEntity;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.PagedResources;
@@ -134,36 +132,7 @@ public class AccountsController {
     @PathVariable(ACCOUNT_ID) final AccountId accountId,
     @RequestBody final AccountSettings.AbstractAccountSettings accountSettings
   ) {
-
-    return accountManager.getAccountSettingsRepository().findByAccountId(accountId)
-      .map(entity -> {
-
-        // Ignore update accountId
-
-        entity.setAssetCode(accountSettings.getAssetCode());
-        entity.setAssetScale(accountSettings.getAssetScale());
-        entity.setAccountRelationship(accountSettings.getAccountRelationship());
-        entity.setBalanceSettings(
-          new AccountBalanceSettingsEntity(accountSettings.getBalanceSettings())
-        );
-        entity.setConnectionInitiator(accountSettings.isConnectionInitiator());
-        entity.setDescription(accountSettings.getDescription());
-        entity.setCustomSettings(accountSettings.getCustomSettings());
-        entity.setIlpAddressSegment(accountSettings.getIlpAddressSegment());
-        entity.setInternal(accountSettings.isInternal());
-        entity.setLinkType(accountSettings.getLinkType());
-        entity.setMaximumPacketAmount(accountSettings.getMaximumPacketAmount());
-        entity.setRateLimitSettings(
-          new AccountRateLimitSettingsEntity(accountSettings.getRateLimitSettings())
-        );
-        entity.setReceiveRoutes(accountSettings.isReceiveRoutes());
-        entity.setSendRoutes(accountSettings.isSendRoutes());
-
-        return accountManager.getAccountSettingsRepository().save(entity);
-      })
-      .map(accountSettingsEntity -> conversionService.convert(accountSettingsEntity, AccountSettings.class))
-      .map(this::toResource)
-      .orElseThrow(() -> new AccountNotFoundProblem(accountId));
+    return this.toResource(accountManager.updateAccount(accountId, accountSettings));
   }
 
   private Resource<AccountSettings> toResource(final AccountSettings accountSettings) {

--- a/ilpv4-connector-service-api/src/main/java/com/sappenin/interledger/ilpv4/connector/accounts/AccountManager.java
+++ b/ilpv4-connector-service-api/src/main/java/com/sappenin/interledger/ilpv4/connector/accounts/AccountManager.java
@@ -34,9 +34,22 @@ public interface AccountManager {
    *
    * @param accountSettings The {@link AccountSettings} for this account.
    *
-   * @return The newly-created settings.
+   * @return The newly-created {@link AccountSettings}.
    */
   AccountSettings createAccount(AccountSettings accountSettings);
+
+  /**
+   * Update an existing account in this connector by storing all account details into the persistent store. This method
+   * should also update a Settlement Account inside any configured settlement engines, if appropriate.
+   *
+   * @param accountId       The {@link AccountId} to update settings for. Note this value trumps {@link
+   *                        AccountSettings#getAccountId()} so that the value specified in the URL paths can always be
+   *                        directly supplied to this method.
+   * @param accountSettings The {@link AccountSettings} for this account.
+   *
+   * @return The update {@link AccountSettings}.
+   */
+  AccountSettings updateAccount(AccountId accountId, AccountSettings accountSettings);
 
   /**
    * Helper method to initialize the parent account using IL-DCP. If this Connector is starting in `child` mode, it will

--- a/ilpv4-connector-service-api/src/main/java/com/sappenin/interledger/ilpv4/connector/settlement/SettlementEngineClient.java
+++ b/ilpv4-connector-service-api/src/main/java/com/sappenin/interledger/ilpv4/connector/settlement/SettlementEngineClient.java
@@ -30,7 +30,11 @@ public interface SettlementEngineClient {
    *                                       `123` might use a settlementEngineAccountId of `peer.settle.123`.
    *                                       Alternatively, it might re-used the same identifier for convenience.
    *
-   * @return A {@link CreateSettlementAccountResponse}
+   * @return A {@link CreateSettlementAccountResponse} that contains a settlement engine accountId as chosen by the
+   * settlement engine. Note that this identifier _may_ match the value supplied by {@code accountId}, although some SE
+   * implementations may choose to not honor this and generate a new identifeir. As such, all implementations SHOULD
+   * assume that the identifier used by the settlement engine is different from the {@code accountId} supplied to this
+   * method.
    *
    * @throws SettlementEngineClientException if the account is unable to be created.
    */

--- a/ilpv4-connector-service-api/src/main/java/com/sappenin/interledger/ilpv4/connector/settlement/SettlementEngineClient.java
+++ b/ilpv4-connector-service-api/src/main/java/com/sappenin/interledger/ilpv4/connector/settlement/SettlementEngineClient.java
@@ -10,6 +10,7 @@ import org.interledger.ilpv4.connector.settlement.client.InitiateSettlementReque
 import org.interledger.ilpv4.connector.settlement.client.InitiateSettlementResponse;
 import org.interledger.ilpv4.connector.settlement.client.SendMessageRequest;
 import org.interledger.ilpv4.connector.settlement.client.SendMessageResponse;
+import org.interledger.ilpv4.connector.settlement.client.SettlementAccount;
 
 /**
  * Defines a client that can interact with a Settlement Engine, from the perspective of a Connector.
@@ -45,6 +46,59 @@ public interface SettlementEngineClient {
   ) throws SettlementEngineClientException;
 
   /**
+   * Update a settlement account in the settlement engine.
+   *
+   * @param accountId                 The {@link AccountId} of the Connector account this request is being executed on
+   *                                  behalf of (for logging purposes).
+   * @param settlementEngineAccountId The {@link SettlementEngineAccountId} that identifies the account in the
+   *                                  settlement engine.
+   * @param settlementEngineBaseUrl   A {@link HttpUrl} for the settlement engine. This value is in this API contract
+   *                                  because this interface merely provides a type-safe implementation over the
+   *                                  underlying client, which will manage HTTP connections internally based upon http
+   *                                  host.
+   * @param settlementAccount         The identifier that a Connector uses to correlate a Connector Account to the
+   *                                  account in the Settlement Engine. For example, a Connector with accountId of `123`
+   *                                  might use a settlementEngineAccountId of `peer.settle.123`. Alternatively, it
+   *                                  might re-used the same identifier for convenience.
+   *
+   * @return A {@link CreateSettlementAccountResponse} that contains a settlement engine accountId as chosen by the
+   * settlement engine. Note that this identifier _may_ match the value supplied by {@code accountId}, although some SE
+   * implementations may choose to not honor this and generate a new identifeir. As such, all implementations SHOULD
+   * assume that the identifier used by the settlement engine is different from the {@code accountId} supplied to this
+   * method.
+   *
+   * @throws SettlementEngineClientException if the account is unable to be updated.
+   */
+  SettlementAccount updateSettlementAccount(
+    AccountId accountId,
+    SettlementEngineAccountId settlementEngineAccountId,
+    HttpUrl settlementEngineBaseUrl,
+    SettlementAccount settlementAccount
+  ) throws SettlementEngineClientException;
+
+  /**
+   * Create a settlement account in the settlement engine.
+   *
+   * @param accountId                 The {@link AccountId} of the Connector account this request is being executed on
+   *                                  behalf of (for logging purposes).
+   * @param settlementEngineAccountId The {@link SettlementEngineAccountId} that identifies the account in the
+   *                                  settlement engine.
+   * @param settlementEngineBaseUrl   A {@link HttpUrl} for the settlement engine. This value is in this API contract
+   *                                  because this interface merely provides a type-safe implementation over the
+   *                                  underlying client, which will manage HTTP connections internally based upon http
+   *                                  host.
+   *
+   * @return
+   *
+   * @throws SettlementEngineClientException if the account is unable to be deleted.
+   */
+  void deleteSettlementAccount(
+    AccountId accountId,
+    SettlementEngineAccountId settlementEngineAccountId,
+    HttpUrl settlementEngineBaseUrl
+  ) throws SettlementEngineClientException;
+
+  /**
    * Send a request to the settlement engine to initiate a settlement payment.
    *
    * @param accountId                 The {@link AccountId} of the Router account making this request.
@@ -53,7 +107,7 @@ public interface SettlementEngineClient {
    *                                  creation on the settlement engine, so this field allows this value to diverge from
    *                                  {@code accountId}.
    * @param idempotencyKey
-   * @param endpointUrl               A {@link HttpUrl} for the settlement engine. This value is in this API contract
+   * @param settlementEngineBaseUrl   A {@link HttpUrl} for the settlement engine. This value is in this API contract
    *                                  because this interface merely provides a type-safe implementation over the
    *                                  underlying client, which will manage HTTP connections internally based upon http
    *                                  host.
@@ -68,7 +122,7 @@ public interface SettlementEngineClient {
     AccountId accountId,
     SettlementEngineAccountId settlementEngineAccountId,
     String idempotencyKey,
-    HttpUrl endpointUrl,
+    HttpUrl settlementEngineBaseUrl,
     InitiateSettlementRequest initiateSettlementRequest
   ) throws SettlementEngineClientException;
 

--- a/ilpv4-connector-service-api/src/main/java/org/interledger/ilpv4/connector/settlement/SettlementEngineClientException.java
+++ b/ilpv4-connector-service-api/src/main/java/org/interledger/ilpv4/connector/settlement/SettlementEngineClientException.java
@@ -14,7 +14,7 @@ import java.util.StringJoiner;
 public class SettlementEngineClientException extends RuntimeException {
 
   /**
-   * The {@link AccountId} of the account that threw an exception while communicating to a Settlment Engine.
+   * The {@link AccountId} of the account that threw an exception while communicating to a Settlement Engine.
    */
   private final AccountId accountId;
 
@@ -73,6 +73,27 @@ public class SettlementEngineClientException extends RuntimeException {
     super(message, cause);
     this.accountId = Objects.requireNonNull(accountId);
     this.settlementEngineAccountId = Objects.requireNonNull(settlementEngineAccountId);
+  }
+
+  /**
+   * Constructs a new runtime exception with the specified detail message and cause.  <p>Note that the detail message
+   * associated with {@code cause} is <i>not</i> automatically incorporated in this runtime exception's detail message.
+   *
+   * @param message                   the detail message (which is saved for later retrieval by the {@link
+   *                                  #getMessage()} method).
+   * @param cause                     the cause (which is saved for later retrieval by the {@link #getCause()} method).
+   *                                  (A
+   *                                  <tt>null</tt> value is permitted, and indicates that the cause is nonexistent or
+   *                                  unknown.)
+   * @param accountId
+   * @param settlementEngineAccountId
+   *
+   * @since 1.4
+   */
+  public SettlementEngineClientException(String message, Throwable cause, AccountId accountId, SettlementEngineAccountId settlementEngineAccountId) {
+    super(message, cause);
+    this.accountId = Objects.requireNonNull(accountId);
+    this.settlementEngineAccountId = Optional.ofNullable(settlementEngineAccountId);
   }
 
   /**

--- a/ilpv4-connector-service-api/src/main/java/org/interledger/ilpv4/connector/settlement/client/SettlementAccount.java
+++ b/ilpv4-connector-service-api/src/main/java/org/interledger/ilpv4/connector/settlement/client/SettlementAccount.java
@@ -1,0 +1,28 @@
+package org.interledger.ilpv4.connector.settlement.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+import org.interledger.connector.accounts.SettlementEngineAccountId;
+
+/**
+ * Models a settlement account's state as reported by the settlement engine.
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableSettlementAccount.class)
+@JsonDeserialize(as = ImmutableSettlementAccount.class)
+public interface SettlementAccount {
+
+  static ImmutableSettlementAccount.Builder builder() {
+    return ImmutableSettlementAccount.builder();
+  }
+
+  /**
+   * The connector's account scale.
+   *
+   * @return An integer representing the scale used by the settlement engine.
+   */
+  @JsonProperty("id")
+  SettlementEngineAccountId settlementAccountId();
+}


### PR DESCRIPTION
Initial WIP for updating accounts via HTTP API (e.g., PUT `/accounts/{accountId}` and logic surrounding what should happen when settlement accounts are updated.