### PR TITLE
Don't error on $0 (no-op) prepare packets

### DIFF
--- a/connector-service-impl/src/main/java/org/interledger/connector/balances/RedisBalanceTracker.java
+++ b/connector-service-impl/src/main/java/org/interledger/connector/balances/RedisBalanceTracker.java
@@ -91,7 +91,7 @@ public class RedisBalanceTracker implements BalanceTracker {
     // theoretically try to make this work, we dont expect _very large_ packet amounts in ILP, and if we encounter
     // them, it probably means the scaling is mis-configured. Additionally, balance tracking has particularly
     // sensitive performance requirements, so any computational savings we can get in ILPv4 the happy-path is preferred.
-    Preconditions.checkArgument(amount >= 0, String.format("amount `%s` must be a positive signed long!", amount));
+    Preconditions.checkArgument(amount >= 0, String.format("amount `%s` cannot be negative!", amount));
     minBalance.ifPresent($ -> Preconditions.checkArgument(
       amount >= 0, String.format("minBalance `%s` must be a positive signed long!", $)
     ));
@@ -137,11 +137,8 @@ public class RedisBalanceTracker implements BalanceTracker {
     // See note in updateBalanceForPrepare for why this is not using unsigned longs
     Preconditions.checkArgument(
       amount >= 0,
-      String.format("amount `%s` must be a positive signed long!", amount)
+      String.format("amount `%s` cannot be negative!", amount)
     );
-
-    // This is here so that we don't hit the balance tracker for any 0-value packets.
-    Preconditions.checkArgument(amount > 0, "destinationAmount must be positive, but was " + amount);
 
     try {
       // Response Format: `{ clearing_balance, prepaid_amount, settle_amount }`

--- a/connector-service-impl/src/test/java/org/interledger/connector/balances/AbstractRedisBalanceTrackerTest.java
+++ b/connector-service-impl/src/test/java/org/interledger/connector/balances/AbstractRedisBalanceTrackerTest.java
@@ -46,6 +46,7 @@ public abstract class AbstractRedisBalanceTrackerTest {
   protected static final long NINE = 9L;
   protected static final long TEN = 10L;
   protected static final long NEGATIVE_TEN = -10L;
+  protected static final long PREPARE_ZERO = ZERO;
   protected static final long PREPARE_ONE = ONE;
   protected static final long PREPARE_TEN = TEN;
   protected static final long TWENTY = 20L;

--- a/connector-service-impl/src/test/java/org/interledger/connector/balances/RedisBalanceTrackerFulfillPacketSettlementTest.java
+++ b/connector-service-impl/src/test/java/org/interledger/connector/balances/RedisBalanceTrackerFulfillPacketSettlementTest.java
@@ -147,7 +147,10 @@ public class RedisBalanceTrackerFulfillPacketSettlementTest extends AbstractRedi
 
       // clearing_balance > settle_to (script will add 1 to 10 and then evaluate)
       new Object[]{10, ZERO, PREPARE_ONE, Optional.of(5L), 0L, 11L}, //27
-      new Object[]{10, 10, PREPARE_ONE, Optional.of(5L), 0L, 11L} //28
+      new Object[]{10, 10, PREPARE_ONE, Optional.of(5L), 0L, 11L}, //28
+
+      // prepare amount zero (no-op) packets
+      new Object[]{5L, 10L, PREPARE_ZERO, Optional.of(10L), 5L, 0L} //29
     );
   }
 

--- a/connector-service-impl/src/test/java/org/interledger/connector/balances/RedisBalanceTrackerRejectPacketTest.java
+++ b/connector-service-impl/src/test/java/org/interledger/connector/balances/RedisBalanceTrackerRejectPacketTest.java
@@ -88,7 +88,10 @@ public class RedisBalanceTrackerRejectPacketTest extends AbstractRedisBalanceTra
       // Prepaid amt > from_amt
       new Object[]{NEGATIVE_ONE, TEN, PREPARE_ONE, ZERO, TEN},
       // Prepaid_amt < from_amt, but > 0
-      new Object[]{TEN, ONE, PREPARE_TEN, TWENTY, ONE}
+      new Object[]{TEN, ONE, PREPARE_TEN, TWENTY, ONE},
+
+      // zero reject amount packet (no-op)
+      new Object[]{TEN, ONE, PREPARE_ZERO, TEN, ONE}
     );
   }
 

--- a/connector-service-impl/src/test/java/org/interledger/connector/links/DefaultNextHopPacketMapperTest.java
+++ b/connector-service-impl/src/test/java/org/interledger/connector/links/DefaultNextHopPacketMapperTest.java
@@ -28,9 +28,11 @@ import org.interledger.link.LoopbackLink;
 import com.google.common.primitives.UnsignedLong;
 import org.javamoney.moneta.spi.DefaultNumberValue;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runners.MethodSorters;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
@@ -49,6 +51,7 @@ import javax.money.convert.ExchangeRate;
 /**
  * Unit tests for {@link DefaultNextHopPacketMapper}.
  */
+@FixMethodOrder(MethodSorters.DEFAULT)
 public class DefaultNextHopPacketMapperTest {
 
   private static final ImmutableRoute NEXT_HOP = Route.builder().nextHopAccountId(AccountId.of("g.ovaltine-jenkins"))


### PR DESCRIPTION
$0 packets are legit for probing fx rates. Let them fall to balance tracker. Fixes issue #334 