### PR TITLE
ability to delete accounts [wip] #171

### DIFF
--- a/connector-accounts/src/main/java/org/interledger/connector/accounts/AccountSettings.java
+++ b/connector-accounts/src/main/java/org/interledger/connector/accounts/AccountSettings.java
@@ -81,6 +81,12 @@ public interface AccountSettings {
   }
 
   /**
+   * Tracks if this record was flagged as deleted as we only do soft deletes of accounts
+   * @return true if the record was deleted
+   */
+  default boolean isDeleted() { return false; }
+
+  /**
    * The segment that will be appended to the connector's ILP address to form this account's ILP address. Only
    * applicable to accounts with relation of {@link AccountRelationship#CHILD}. By default, this will be the identifier
    * of the account.
@@ -217,7 +223,7 @@ public interface AccountSettings {
   @JsonSerialize(as = ImmutableAccountSettings.class)
   @JsonDeserialize(as = ImmutableAccountSettings.class)
   @JsonPropertyOrder( {"accountId", "createdAt", "modifiedAt", "description", "accountRelationship", "assetCode",
-    "assetScale", "maximumPacketAmount", "linkType", "ilpAddressSegment", "connectionInitiator",
+    "assetScale", "maximumPacketAmount", "linkType", "ilpAddressSegment", "connectionInitiator", "deleted",
     "internal", "sendRoutes", "receiveRoutes", "balanceSettings", "rateLimitSettings",
     "settlementEngineDetails", "customSettings"})
   abstract class AbstractAccountSettings implements AccountSettings {
@@ -259,6 +265,11 @@ public interface AccountSettings {
     public boolean isConnectionInitiator() {
       return true;
     }
+
+    @Override
+    @Value.Default
+    @JsonProperty("deleted")
+    public boolean isDeleted() { return false; }
 
     @Value.Default
     @Override

--- a/connector-jackson/src/test/java/org/interledger/connector/jackson/model/AccountSettingsJsonTest.java
+++ b/connector-jackson/src/test/java/org/interledger/connector/jackson/model/AccountSettingsJsonTest.java
@@ -54,6 +54,7 @@ public class AccountSettingsJsonTest {
       "\"linkType\":\"LOOPBACK\"," +
       "\"ilpAddressSegment\":\"bob\"," +
       "\"connectionInitiator\":true," +
+      "\"deleted\":false," +
       "\"internal\":false," +
       "\"sendRoutes\":false," +
       "\"receiveRoutes\":false," +
@@ -120,6 +121,7 @@ public class AccountSettingsJsonTest {
       "\"linkType\":\"LOOPBACK\"," +
       "\"ilpAddressSegment\":\"foo\"," +
       "\"connectionInitiator\":true," +
+      "\"deleted\":false," +
       "\"internal\":true," +
       "\"sendRoutes\":true," +
       "\"receiveRoutes\":true," +

--- a/connector-persistence/src/main/java/org/interledger/connector/persistence/converters/AccountSettingsEntityConverter.java
+++ b/connector-persistence/src/main/java/org/interledger/connector/persistence/converters/AccountSettingsEntityConverter.java
@@ -49,7 +49,8 @@ public class AccountSettingsEntityConverter implements Converter<AccountSettings
       .ilpAddressSegment(accountSettingsEntity.getIlpAddressSegment())
       .isSendRoutes(accountSettingsEntity.isSendRoutes())
       .isReceiveRoutes(accountSettingsEntity.isReceiveRoutes())
-      .putAllCustomSettings(accountSettingsEntity.getCustomSettings());
+      .putAllCustomSettings(accountSettingsEntity.getCustomSettings())
+      .isDeleted(accountSettingsEntity.isDeleted());
 
     accountSettingsEntity.getMaximumPacketAmount()
       .ifPresent(maxPacketAmount -> builder.maximumPacketAmount(UnsignedLong.valueOf(maxPacketAmount)));

--- a/connector-persistence/src/main/java/org/interledger/connector/persistence/entities/AccountSettingsEntity.java
+++ b/connector-persistence/src/main/java/org/interledger/connector/persistence/entities/AccountSettingsEntity.java
@@ -56,6 +56,9 @@ public class AccountSettingsEntity extends AbstractEntity {
   @Column(name = "CONNECTION_INITIATOR")
   private boolean connectionInitiator;
 
+  @Column(name = "DELETED")
+  private boolean deleted;
+
   @Column(name = "ILP_ADDR_SEGMENT")
   private String ilpAddressSegment;
 
@@ -108,6 +111,7 @@ public class AccountSettingsEntity extends AbstractEntity {
     this.description = accountSettings.description();
     this.internal = accountSettings.isInternal();
     this.connectionInitiator = accountSettings.isConnectionInitiator();
+    this.deleted = accountSettings.isDeleted();
     this.ilpAddressSegment = accountSettings.ilpAddressSegment();
     this.accountRelationship = accountSettings.accountRelationship();
     this.linkType = accountSettings.linkType();
@@ -154,6 +158,14 @@ public class AccountSettingsEntity extends AbstractEntity {
 
   public void setConnectionInitiator(boolean connectionInitiator) {
     this.connectionInitiator = connectionInitiator;
+  }
+
+  public boolean isDeleted() {
+    return deleted;
+  }
+
+  public void setDeleted(boolean deleted) {
+    this.deleted = deleted;
   }
 
   public String getIlpAddressSegment() {
@@ -293,6 +305,7 @@ public class AccountSettingsEntity extends AbstractEntity {
   public int hashCode() {
     return Objects.hash(getAccountId());
   }
+
 }
 
 

--- a/connector-persistence/src/main/resources/db/changelogs/base/changelog.xml
+++ b/connector-persistence/src/main/resources/db/changelogs/base/changelog.xml
@@ -34,6 +34,10 @@
         <constraints nullable="false"/>
       </column>
 
+      <column name="DELETED" type="BOOLEAN" defaultValueBoolean="false">
+        <constraints nullable="false"/>
+      </column>
+
       <!-- Purposefully smaller than 1024 to allow for long values with a long prefix -->
       <column name="ILP_ADDR_SEGMENT" type="VARCHAR(512)">
         <constraints nullable="true"/>

--- a/connector-server/src/main/java/org/interledger/connector/server/spring/controllers/admin/AccountsController.java
+++ b/connector-server/src/main/java/org/interledger/connector/server/spring/controllers/admin/AccountsController.java
@@ -189,6 +189,16 @@ public class AccountsController {
       .orElseThrow(() -> new AccountNotFoundProblem(accountId));
   }
 
+  @RequestMapping(
+    path = PathConstants.SLASH_ACCOUNTS + PathConstants.SLASH_ACCOUNT_ID,
+    method = RequestMethod.DELETE,
+    produces = {APPLICATION_JSON_VALUE, MediaTypes.PROBLEM_VALUE}
+  )
+  public ResponseEntity deleteAccountById(@PathVariable(PathConstants.ACCOUNT_ID) final AccountId accountId) {
+    this.accountManager.deleteAccountById(accountId);
+    return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+  }
+
   private EntityModel<AccountSettings> toEntityModel(final AccountSettings accountSettings) {
     Objects.requireNonNull(accountSettings);
 

--- a/connector-server/src/main/java/org/interledger/connector/server/spring/settings/web/SecurityConfiguration.java
+++ b/connector-server/src/main/java/org/interledger/connector/server/spring/settings/web/SecurityConfiguration.java
@@ -193,6 +193,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
       .antMatchers(HttpMethod.GET, PathConstants.SLASH_ACCOUNTS).hasAuthority(AuthConstants.Authorities.CONNECTOR_ADMIN)
       .antMatchers(HttpMethod.GET, PathConstants.SLASH_ACCOUNTS + PathConstants.SLASH_ACCOUNT_ID).hasAuthority(AuthConstants.Authorities.CONNECTOR_ADMIN)
       .antMatchers(HttpMethod.PUT, PathConstants.SLASH_ACCOUNTS + PathConstants.SLASH_ACCOUNT_ID).hasAuthority(AuthConstants.Authorities.CONNECTOR_ADMIN)
+      .antMatchers(HttpMethod.DELETE, PathConstants.SLASH_ACCOUNTS + PathConstants.SLASH_ACCOUNT_ID).hasAuthority(AuthConstants.Authorities.CONNECTOR_ADMIN)
       // /routes
       .antMatchers(HttpMethod.GET, PathConstants.SLASH_ROUTES).hasAuthority(AuthConstants.Authorities.CONNECTOR_ADMIN)
       .antMatchers(HttpMethod.GET, PathConstants.SLASH_ROUTES_STATIC).hasAuthority(AuthConstants.Authorities.CONNECTOR_ADMIN)

--- a/connector-server/src/test/java/org/interledger/connector/server/client/ConnectorAdminClient.java
+++ b/connector-server/src/test/java/org/interledger/connector/server/client/ConnectorAdminClient.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,6 +39,8 @@ public interface ConnectorAdminClient {
   @GetMapping(value = "/accounts/{id}", produces = APPLICATION_JSON_VALUE)
   Optional<ImmutableAccountSettings> findAccount(URI baseURL, @RequestParam("id") String accountId);
 
+  @DeleteMapping(value = "/accounts/{id}", produces = APPLICATION_JSON_VALUE)
+  ResponseEntity<String> deleteAccount(URI baseURL, @RequestParam("id") String accountId);
 
   class ConnectorAdminClientConfiguration {
     @Bean

--- a/connector-server/src/test/java/org/interledger/connector/server/spring/controllers/admin/AccountSettingsSpringBootTest.java
+++ b/connector-server/src/test/java/org/interledger/connector/server/spring/controllers/admin/AccountSettingsSpringBootTest.java
@@ -131,6 +131,38 @@ public class AccountSettingsSpringBootTest {
   }
 
   @Test
+  public void testDelete() {
+    final AccountId accountId = AccountId.of(UUID.randomUUID().toString());
+    AccountSettings settings = AccountSettings.builder()
+      .accountId(accountId)
+      .accountRelationship(AccountRelationship.CHILD)
+      .assetCode("FUD")
+      .assetScale(6)
+      .linkType(LoopbackLink.LINK_TYPE)
+      .createdAt(Instant.now())
+      .build();
+
+    AccountSettings response = assertPostAccount(settings, HttpStatus.CREATED);
+    assertThat(response).isEqualTo(settings);
+
+    ResponseEntity<String> deleteResponse = deleteAccount(accountId.value());
+    assertThat(deleteResponse.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+  }
+
+  @Test
+  public void testDeleteUnknown404s() {
+    String accountId = UUID.randomUUID().toString();
+    ResponseEntity<String> deleteResponse = deleteAccount(accountId);
+
+    JsonContentAssert assertJson = assertThat(jsonTester.from(deleteResponse.getBody()));
+    assertJson.extractingJsonPathValue("status").isEqualTo(404);
+    assertJson.extractingJsonPathValue("title").isEqualTo("Account Not Found (`" + accountId + "`)");
+    assertJson.extractingJsonPathValue("accountId").isEqualTo(accountId);
+    assertJson.extractingJsonPathValue("type")
+      .isEqualTo("https://errors.interledger.org/accounts/account-not-found");
+  }
+
+  @Test
   public void testFullyPopulatedCreate() {
     final AccountId accountId = AccountId.of(UUID.randomUUID().toString());
     final AccountSettings settings = constructFullyPopulatedAccountSettings(accountId);
@@ -310,6 +342,10 @@ public class AccountSettingsSpringBootTest {
     }
     fail("Expected failure");
     return "not reachable";
+  }
+
+  private ResponseEntity<String> deleteAccount(String accountId) {
+    return adminClient.deleteAccount(baseURI, accountId);
   }
 
   private ImmutableAccountSettings constructFullyPopulatedAccountSettings(final AccountId accountId) {

--- a/connector-service-api/src/main/java/org/interledger/connector/accounts/AccountManager.java
+++ b/connector-service-api/src/main/java/org/interledger/connector/accounts/AccountManager.java
@@ -48,4 +48,10 @@ public interface AccountManager {
    */
   AccountSettings initializeParentAccountSettingsViaIlDcp(AccountId primaryParentAccountId);
 
+  /**
+   * Marks an account as deleted by its account id
+   * @param accountId the {@link AccountId} of the account to be marked deleted
+   */
+  void deleteAccountById(AccountId accountId);
+
 }

--- a/connector-service-impl/src/main/java/org/interledger/connector/accounts/DefaultAccountManager.java
+++ b/connector-service-impl/src/main/java/org/interledger/connector/accounts/DefaultAccountManager.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.ConversionService;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -239,5 +240,18 @@ public class DefaultAccountManager implements AccountManager {
     );
 
     return conversionService.convert(updatedAccountSettings, AccountSettings.class);
+  }
+
+  @Override
+  public void deleteAccountById(AccountId accountId) {
+    Optional<AccountSettingsEntity> account = accountSettingsRepository.findByAccountId(accountId);
+    if (account.isPresent()) {
+      AccountSettingsEntity accountSettings = account.get();
+      accountSettings.setDeleted(true);
+      accountSettingsRepository.save(accountSettings);
+    }
+    else  {
+      throw new AccountNotFoundProblem(accountId);
+    }
   }
 }


### PR DESCRIPTION
I added the resource and updated the entity to have a flag to mark things as deleted, but I wasn't quite sure exactly how you wanted to go about using the flag: if you want to update any selects to check for the flag and have some kind of way to fetch everything vs fetching non-deleted, or if you wanted to check the flag on the object itself in specific areas of the code. I also wasn't sure if the `GET` on the controller should 404 if the entity is marked as deleted or if it should just return the entity with the flag marked.